### PR TITLE
Prism interaction

### DIFF
--- a/Assets/Materials.meta
+++ b/Assets/Materials.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: fbc2863b1919f274ab545f5b2a71a753
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Resources.meta
+++ b/Assets/Resources.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 398bc3f2596d31f4398468420d707a21
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scenes/TestScene.unity
+++ b/Assets/Scenes/TestScene.unity
@@ -2439,6 +2439,7 @@ GameObject:
   - component: {fileID: 1953576800}
   - component: {fileID: 1953576799}
   - component: {fileID: 1953576798}
+  - component: {fileID: 1953576803}
   - component: {fileID: 1953576797}
   m_Layer: 0
   m_Name: Player
@@ -2564,6 +2565,31 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &1953576803
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1953576796}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 2, y: 2}
+  m_EdgeRadius: 0
 --- !u!1 &2006358132
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/TestScene.unity
+++ b/Assets/Scenes/TestScene.unity
@@ -2438,6 +2438,7 @@ GameObject:
   - component: {fileID: 1953576801}
   - component: {fileID: 1953576800}
   - component: {fileID: 1953576799}
+  - component: {fileID: 1953576804}
   - component: {fileID: 1953576798}
   - component: {fileID: 1953576803}
   - component: {fileID: 1953576797}
@@ -2590,6 +2591,17 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 2, y: 2}
   m_EdgeRadius: 0
+--- !u!114 &1953576804
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1953576796}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d86b4fb632d7e472fa23fd67f6a4882a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &2006358132
 GameObject:
   m_ObjectHideFlags: 0
@@ -2786,6 +2798,125 @@ MeshFilter:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2031936618}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &2053429639
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2053429644}
+  - component: {fileID: 2053429643}
+  - component: {fileID: 2053429642}
+  - component: {fileID: 2053429641}
+  - component: {fileID: 2053429640}
+  m_Layer: 0
+  m_Name: Prism
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!61 &2053429640
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2053429639}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!50 &2053429641
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2053429639}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!23 &2053429642
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2053429639}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 4294967295
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &2053429643
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2053429639}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &2053429644
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2053429639}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 2, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2067738924
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/TestScene.unity
+++ b/Assets/Scenes/TestScene.unity
@@ -2808,11 +2808,10 @@ GameObject:
   - component: {fileID: 2053429644}
   - component: {fileID: 2053429643}
   - component: {fileID: 2053429642}
-  - component: {fileID: 2053429641}
   - component: {fileID: 2053429640}
   m_Layer: 0
   m_Name: Prism
-  m_TagString: Untagged
+  m_TagString: Prism
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -2842,26 +2841,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
---- !u!50 &2053429641
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 2053429639}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 1
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 1
-  m_Material: {fileID: 0}
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
 --- !u!23 &2053429642
 MeshRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/TestScene.unity
+++ b/Assets/Scenes/TestScene.unity
@@ -2602,6 +2602,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d86b4fb632d7e472fa23fd67f6a4882a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  rotateTag: Prism
 --- !u!1 &2006358132
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/PrismInteraction.cs
+++ b/Assets/Scripts/PrismInteraction.cs
@@ -5,6 +5,8 @@ using UnityEngine;
 public class PrismInteraction : MonoBehaviour {
 
     [Tooltip("Object with this tag will be rotated")] public string rotateTag = "Prism";
+    [Tooltip("How much to rotate the object by")] public int degrees = 45;
+
 
     // Rotates anything tagged 'tagToRotate' when E is pressed
     private void OnTriggerStay2D(Collider2D collision) {
@@ -15,7 +17,7 @@ public class PrismInteraction : MonoBehaviour {
             // If the thing with which you are colliding is a prism, rotate it
             if (collision.tag == rotateTag)
             {
-                collision.transform.Rotate(new Vector3(0, 0, 45));
+                collision.transform.Rotate(new Vector3(0, 0, degrees));
             }
         }
     }

--- a/Assets/Scripts/PrismInteraction.cs
+++ b/Assets/Scripts/PrismInteraction.cs
@@ -4,21 +4,17 @@ using UnityEngine;
 
 public class PrismInteraction : MonoBehaviour {
 
-	// Use this for initialization
-	void Start () {
+    // Rotates anything tagged 'Prism' when E is pressed
+    private void OnTriggerStay2D(Collider2D collision) {
 
-	}
-	
-	// Update is called once per frame
-	void Update () {
-		
-	}
-
-    private void OnTriggerEnter2D(Collider2D collision) {
-
-        if (collision.tag == "Prism")
+        // Interact key
+        if (Input.GetKeyDown(KeyCode.E))
         {
-            collision.transform.Rotate(new Vector3(0, 0, 45));
+            // If the thing with which you are colliding is a prism, rotate it
+            if (collision.tag == "Prism")
+            {
+                collision.transform.Rotate(new Vector3(0, 0, 45));
+            }
         }
     }
 }

--- a/Assets/Scripts/PrismInteraction.cs
+++ b/Assets/Scripts/PrismInteraction.cs
@@ -6,11 +6,19 @@ public class PrismInteraction : MonoBehaviour {
 
 	// Use this for initialization
 	void Start () {
-		
+
 	}
 	
 	// Update is called once per frame
 	void Update () {
 		
 	}
+
+    private void OnTriggerEnter2D(Collider2D collision) {
+
+        if (collision.tag == "Prism")
+        {
+            collision.transform.Rotate(new Vector3(0, 0, 45));
+        }
+    }
 }

--- a/Assets/Scripts/PrismInteraction.cs
+++ b/Assets/Scripts/PrismInteraction.cs
@@ -4,7 +4,9 @@ using UnityEngine;
 
 public class PrismInteraction : MonoBehaviour {
 
-    // Rotates anything tagged 'Prism' when E is pressed
+    [Tooltip("Object with this tag will be rotated")] public string rotateTag;
+
+    // Rotates anything tagged 'tagToRotate' when E is pressed
     private void OnTriggerStay2D(Collider2D collision) {
 
         // Interact key

--- a/Assets/Scripts/PrismInteraction.cs
+++ b/Assets/Scripts/PrismInteraction.cs
@@ -2,23 +2,59 @@
 using System.Collections.Generic;
 using UnityEngine;
 
+/*
+ * This script can be attached to the player. If we create a trigger box around the player, 
+ * this script will rotate any object tagged 'rotateTag' by 'degrees' once the player's 
+ * trigger box enters the object and the key 'keyCode' is pressed.
+ */
+
 public class PrismInteraction : MonoBehaviour {
 
-    [Tooltip("Object with this tag will be rotated")] public string rotateTag = "Prism";
-    [Tooltip("How much to rotate the object by")] public int degrees = 45;
+    [Tooltip("Object with this tag will be rotated")] 
+    public string rotateTag = "Prism";
 
+    [Tooltip("How much to rotate the object by")]
+    public int degrees = 45;
+
+    [Tooltip("Which key is used for rotation")] [SerializeField] 
+    public KeyCode keyCode = KeyCode.E;
+
+    // Is the player in range to rotate object (e.i. is the trigger inside)
+    private bool isInRange = false;
+
+    // All of the objects that the player is currently "colliding" with (e.i. the objects to possibly rotate)
+    private List<GameObject> currentlyColliding = new List<GameObject>();
+
+    void Update() {
+        // If key pressed, in range, and colliding object is not null...
+        if (Input.GetKeyDown(keyCode) && isInRange)
+        {
+            // If the thing with which you are colliding with is tagged correctly, rotate it
+            for (int i = 0; i < currentlyColliding.Count; i++)
+            {
+                if (currentlyColliding[i].tag == rotateTag)
+                {
+                    currentlyColliding[i].transform.Rotate(new Vector3(0, 0, degrees));
+                }
+            }  
+        }
+    }
+
+    /*
+     * I tried doing this with OnTriggerStay2D, but it was buggy so I decided to use this method instead.
+     * It is much cleaner and smoothe with OnEnter and OnStay with a boolean.
+     */
 
     // Rotates anything tagged 'tagToRotate' when E is pressed
-    private void OnTriggerStay2D(Collider2D collision) {
+    private void OnTriggerEnter2D(Collider2D collision) {
+        isInRange = true;
+        
+        currentlyColliding.Add(collision.transform.gameObject);
+    }
 
-        // Interact key
-        if (Input.GetKeyDown(KeyCode.E))
-        {
-            // If the thing with which you are colliding is a prism, rotate it
-            if (collision.tag == rotateTag)
-            {
-                collision.transform.Rotate(new Vector3(0, 0, degrees));
-            }
-        }
+    private void OnTriggerExit2D(Collider2D collision) {
+        isInRange = false;
+
+        currentlyColliding.Remove(collision.transform.gameObject);
     }
 }

--- a/Assets/Scripts/PrismInteraction.cs
+++ b/Assets/Scripts/PrismInteraction.cs
@@ -12,22 +12,19 @@ public class PrismInteraction : MonoBehaviour {
 
     [Tooltip("Object with this tag will be rotated")] 
     public string rotateTag = "Prism";
-
+        
     [Tooltip("How much to rotate the object by")]
     public int degrees = 45;
 
     [Tooltip("Which key is used for rotation")] [SerializeField] 
     public KeyCode keyCode = KeyCode.E;
 
-    // Is the player in range to rotate object (e.i. is the trigger inside)
-    private bool isInRange = false;
-
     // All of the objects that the player is currently "colliding" with (e.i. the objects to possibly rotate)
     private List<GameObject> currentlyColliding = new List<GameObject>();
 
     void Update() {
         // If key pressed, in range, and colliding object is not null...
-        if (Input.GetKeyDown(keyCode) && isInRange)
+        if (Input.GetKeyDown(keyCode))
         {
             // If the thing with which you are colliding with is tagged correctly, rotate it
             for (int i = 0; i < currentlyColliding.Count; i++)
@@ -47,14 +44,10 @@ public class PrismInteraction : MonoBehaviour {
 
     // Rotates anything tagged 'tagToRotate' when E is pressed
     private void OnTriggerEnter2D(Collider2D collision) {
-        isInRange = true;
-        
         currentlyColliding.Add(collision.transform.gameObject);
     }
 
     private void OnTriggerExit2D(Collider2D collision) {
-        isInRange = false;
-
         currentlyColliding.Remove(collision.transform.gameObject);
     }
 }

--- a/Assets/Scripts/PrismInteraction.cs
+++ b/Assets/Scripts/PrismInteraction.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PrismInteraction : MonoBehaviour {
+
+	// Use this for initialization
+	void Start () {
+		
+	}
+	
+	// Update is called once per frame
+	void Update () {
+		
+	}
+}

--- a/Assets/Scripts/PrismInteraction.cs
+++ b/Assets/Scripts/PrismInteraction.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class PrismInteraction : MonoBehaviour {
 
-    [Tooltip("Object with this tag will be rotated")] public string rotateTag;
+    [Tooltip("Object with this tag will be rotated")] public string rotateTag = "Prism";
 
     // Rotates anything tagged 'tagToRotate' when E is pressed
     private void OnTriggerStay2D(Collider2D collision) {
@@ -13,7 +13,7 @@ public class PrismInteraction : MonoBehaviour {
         if (Input.GetKeyDown(KeyCode.E))
         {
             // If the thing with which you are colliding is a prism, rotate it
-            if (collision.tag == "Prism")
+            if (collision.tag == rotateTag)
             {
                 collision.transform.Rotate(new Vector3(0, 0, 45));
             }

--- a/Assets/Scripts/PrismInteraction.cs.meta
+++ b/Assets/Scripts/PrismInteraction.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d86b4fb632d7e472fa23fd67f6a4882a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Textures.meta
+++ b/Assets/Textures.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: ace08878d82562746a197c77763940da
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -3,7 +3,8 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - Prism
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
Made a new 'PrismInteraction' script which can be attached to the player. If we add a trigger box around the player as well as create an object tagged 'Prism' (or anything else specified), it rotates that object by 45 (or anything else specified) degrees when the key 'E' (or anything else specified) is pressed and the player's trigger box is colliding with the prism. 